### PR TITLE
Added virtual destructor to matrix_class since valgrind checks failed

### DIFF
--- a/include/matrix_market_reader.h
+++ b/include/matrix_market_reader.h
@@ -66,6 +66,8 @@ public:
   matrix_class () = delete;
   explicit matrix_class (matrix_meta meta_arg) : meta (meta_arg) { }
 
+  virtual ~matrix_class() = default;
+
   size_t get_rows_count () const { return meta.rows_count; }
   size_t get_cols_count () const { return meta.cols_count; }
 


### PR DESCRIPTION
I encountered the post on medium https://medium.com/analytics-vidhya/sparse-matrix-vector-multiplication-with-cuda-42d191878e8f since I was interested in sparse matrices stuff. I ran the minimal example through Valgrind and it has shown 3 leaks in row_ids.reset (new unsigned int[meta.non_zero_count]); and similar snippets that leverage unique_ptrs:

```==144277== Memcheck, a memory error detector
==144277== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==144277== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==144277== Command: ./MatrixMarket
==144277== 
....
==144277== 
==144277== HEAP SUMMARY:
==144277==     in use at exit: 128 bytes in 3 blocks
==144277==   total heap usage: 44 allocs, 41 frees, 83,770 bytes allocated
==144277== 
==144277== 32 bytes in 1 blocks are definitely lost in loss record 1 of 3
==144277==    at 0x4A38C17: operator new[](unsigned long) (vg_replace_malloc.c:431)
==144277==    by 0x10EE12: sparse_reader::sparse_reader(matrix_market::matrix_class::matrix_meta) (matrix_market_reader.cpp:186)
==144277==    by 0x10FE2D: std::_MakeUniq<sparse_reader>::__single_object std::make_unique<sparse_reader, matrix_market::matrix_class::matrix_meta const&>(matrix_market::matrix_class::matrix_meta const&) (unique_ptr.h:857)
==144277==    by 0x10E4A3: create_reader(matrix_market::matrix_class::matrix_meta const&) (matrix_market_reader.cpp:237)
==144277==    by 0x10E74E: matrix_market::reader::reader(std::istream&, bool) (matrix_market_reader.cpp:264)
==144277==    by 0x10A50D: main (test_matrix_market.cpp:126)
==144277== 
==144277== 32 bytes in 1 blocks are definitely lost in loss record 2 of 3
==144277==    at 0x4A38C17: operator new[](unsigned long) (vg_replace_malloc.c:431)
==144277==    by 0x10EE3A: sparse_reader::sparse_reader(matrix_market::matrix_class::matrix_meta) (matrix_market_reader.cpp:187)
==144277==    by 0x10FE2D: std::_MakeUniq<sparse_reader>::__single_object std::make_unique<sparse_reader, matrix_market::matrix_class::matrix_meta const&>(matrix_market::matrix_class::matrix_meta const&) (unique_ptr.h:857)
==144277==    by 0x10E4A3: create_reader(matrix_market::matrix_class::matrix_meta const&) (matrix_market_reader.cpp:237)
==144277==    by 0x10E74E: matrix_market::reader::reader(std::istream&, bool) (matrix_market_reader.cpp:264)
==144277==    by 0x10A50D: main (test_matrix_market.cpp:126)
==144277== 
==144277== 64 bytes in 1 blocks are definitely lost in loss record 3 of 3
==144277==    at 0x4A38C17: operator new[](unsigned long) (vg_replace_malloc.c:431)
==144277==    by 0x10EE6E: sparse_reader::sparse_reader(matrix_market::matrix_class::matrix_meta) (matrix_market_reader.cpp:190)
==144277==    by 0x10FE2D: std::_MakeUniq<sparse_reader>::__single_object std::make_unique<sparse_reader, matrix_market::matrix_class::matrix_meta const&>(matrix_market::matrix_class::matrix_meta const&) (unique_ptr.h:857)
==144277==    by 0x10E4A3: create_reader(matrix_market::matrix_class::matrix_meta const&) (matrix_market_reader.cpp:237)
==144277==    by 0x10E74E: matrix_market::reader::reader(std::istream&, bool) (matrix_market_reader.cpp:264)
==144277==    by 0x10A50D: main (test_matrix_market.cpp:126)
==144277== 
==144277== LEAK SUMMARY:
==144277==    definitely lost: 128 bytes in 3 blocks
==144277==    indirectly lost: 0 bytes in 0 blocks
==144277==      possibly lost: 0 bytes in 0 blocks
==144277==    still reachable: 0 bytes in 0 blocks
==144277==         suppressed: 0 bytes in 0 blocks
==144277== 
==144277== For lists of detected and suppressed errors, rerun with: -s
==144277== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```

I am not much experienced with C++, but after some reading, it seems to be due to the lack of `virtual ~matrix_class() = default;`